### PR TITLE
fix models.py 'category'

### DIFF
--- a/la_food_oasis/api/models.py
+++ b/la_food_oasis/api/models.py
@@ -14,7 +14,7 @@ class Location(models.Model):
     phone = models.CharField(max_length=20, blank=True)
     latitude = models.DecimalField(max_digits=9, decimal_places=6)
     longitude = models.DecimalField(max_digits=9, decimal_places=6)
-    category = models.CharField(choices=LOCATION_CATEGORIES, blank=True, default='GS', max_length=50)
+    category = models.CharField(choices=LOCATION_CATEGORIES, blank=False, max_length=50)
     website = models.CharField(max_length=60, blank=True, default=''  )
     active = models.BooleanField(default=True)
 


### PR DESCRIPTION
For the integrity of the db, I think that each entry needs a category before being inserted into the db. Without a category, it can't be mapped and also this could result in the entry of a lot of locations with no category that subsequently have to be cleaned/verified. This can be done before insertion via script (happy to write one when the time comes) or (last resort) manual verification instead.  

Also there shouldn't be a default value since it can be any one of the categories and 'GS' might be incorrect and mis-categorize location.