### PR TITLE
change models.py clarify category

### DIFF
--- a/la_food_oasis/api/models.py
+++ b/la_food_oasis/api/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 
 class Location(models.Model):
-    LOCATION_CATEGORIES = (('CG','Community Garden'), ('FM',"Farmer's Market"),('FB','Food Bank'),('GS','Grocery Store'),('SM','Super Market'), ('CV','Convenience Store'))
+    LOCATION_CATEGORIES = (('CG','Community Garden'), ('FM',"Farmer's Market"),('FB','Food Bank'),('GS','Grocery Store'),('SM','Super Market'), ('OS','Other Stores'))
 
     created = models.DateTimeField(auto_now_add=True)
     name = models.CharField(max_length=80, blank=False)


### PR DESCRIPTION
Change to models.py category: From "Convenience Store" to "Other Stores" because convenience stores are just one type of store in this category. For ongoing clarity (ie someone else using the db) I propose using a more expansive category name to clearly show this is a tracked but miscellaneous collection of locations.  Open to other names if anyone prefers something different.